### PR TITLE
GETting empty directories should return an empty object instead of an empty response

### DIFF
--- a/lib/restore.js
+++ b/lib/restore.js
@@ -33,7 +33,7 @@ var Restore = function(options) {
     });
 };
 
-Restore.VALID_PATH = /^\/[a-z0-9\%\-\_\/]*$/i;
+Restore.VALID_PATH = /^\/[a-z0-9\%\-\_\/\.]*$/i;
 
 Restore.prototype.boot = function() {
   if (this._httpServer) this._httpServer.listen(this._options.http.port);


### PR DESCRIPTION
From [2012.04#GET](http://www.w3.org/community/unhosted/wiki/RemoteStorage-2012.04#GET):

> A GET to an empty/absent directory should return a 200 status with a "{}" in the body, rather than a 404 status.
