### PR TITLE
allow dots in filenames

### DIFF
--- a/lib/restore.js
+++ b/lib/restore.js
@@ -34,6 +34,12 @@ var Restore = function(options) {
 };
 
 Restore.VALID_PATH = /^\/[a-z0-9\%\-\_\/\.]*$/i;
+Restore.PROHIBITED_PATH = /\.{2}/;
+
+Restore.validPath = function(path) {
+  return Restore.VALID_PATH.test(path) &&
+    (! Restore.PROHIBITED_PATH.test(path));
+}
 
 Restore.prototype.boot = function() {
   if (this._httpServer) this._httpServer.listen(this._options.http.port);
@@ -101,7 +107,7 @@ Restore.prototype.dispatch = function(request, response) {
         path     = match[2],
         storage  = new Storage(request, response, this._store, username, path);
 
-    if (!Restore.VALID_PATH.test(path)) {
+    if (!Restore.validPath(path)) {
       response.writeHead(400, {'Access-Control-Allow-Origin': '*'});
       return response.end();
     }


### PR DESCRIPTION
the minimal example, which tries to store /notes/note.txt failed with restore, which returned 400 Bad Request.

there may also be other cases where this breaks.

This change may open a security hole with "../" in the path, didn't check :)
