### PR TITLE
Expose ETags of folders

### DIFF
--- a/lib/controllers/storage.js
+++ b/lib/controllers/storage.js
@@ -35,9 +35,9 @@ Storage.action('get', function() {
                  : item  ? 200
                          : 404;
 
-      if (item instanceof Array) {
-        var listing = {}, n = item.length;
-        while (n--) listing[item[n].name] = item[n].modified.toString();
+      if (item && item.children) {
+        var listing = {}, n = item.children.length;
+        while (n--) listing[item.children[n].name] = item.children[n].modified.toString();
         self._headers['Content-Type'] = 'application/json';
         item.value = JSON.stringify(listing, true, 2);
       }

--- a/lib/stores/file_tree.js
+++ b/lib/stores/file_tree.js
@@ -163,17 +163,23 @@ FileTree.prototype.get = function(username, path, version, callback) {
 
   this._lock(username, function(release) {
     if (isdir) {
-      self.childPaths(username, path, function(entries) {
-        if (entries.length === 0) {
-          release();
-          return callback(null, null);
-        }
-        entries = entries.filter(function(e) { return !/\.meta$/.test(e) });
-        async.map(entries, function(entry, callback) {
-          self._getListing(username, path, entry, callback);
-        }, function(error, listing) {
-          release();
-          callback(null, listing);
+      fs.stat(self.dirname(username, path), function(error, stat) {
+        var mtime = stat && new Date(stat.mtime.getTime()).getTime();
+        self.childPaths(username, path, function(entries) {
+          if (entries.length === 0) {
+            release();
+            return callback(null, null);
+          }
+          entries = entries.filter(function(e) { return !/\.meta$/.test(e) });
+          async.map(entries, function(entry, callback) {
+            self._getListing(username, path, entry, callback);
+          }, function(error, listing) {
+            release();
+            callback(null, {
+                modified: mtime,
+                children: listing
+            });
+          });
         });
       });
     } else {

--- a/lib/stores/redis.js
+++ b/lib/stores/redis.js
@@ -166,19 +166,24 @@ RedisStore.prototype.get = function(username, path, version, callback) {
   var key = self._ns + 'users:' + username + ':data:' + path;
   if (isdir) {
     this._lock(username, function(release) {
-      client.smembers(key + ':children', function(error, children) {
-        if (children.length === 0) {
-          release();
-          return callback(null, null);
-        }
-        async.map(children.sort(), function(child, callback) {
-          client.hget(key + child, 'modified', function(error, modified) {
-            callback(error, {name: child, modified: parseInt(modified, 10)});
+      client.hget(key, 'modified', function(error, modified) {
+        modified = parseInt(modified, 10);
+        client.smembers(key + ':children', function(error, children) {
+          if (children.length === 0) {
+            release();
+            return callback(null, null);
+          }
+          async.map(children.sort(), function(child, callback) {
+            client.hget(key + child, 'modified', function(error, modified) {
+              callback(error, {name: child, modified: parseInt(modified, 10)});
+            });
+          }, function(error, listing) {
+            release();
+            callback(null, {
+                modified: modified,
+                children: listing
+            }, self._versionMatch(version, modified));
           });
-
-        }, function(error, listing) {
-          release();
-          callback(null, listing)
         });
       });
     });

--- a/spec/restore/storage_spec.js
+++ b/spec/restore/storage_spec.js
@@ -208,7 +208,7 @@ JS.Test.describe("Storage", function() { with(this) {
     describe("when the store returns a directory listing", function() { with(this) {
       before(function() { with(this) {
         header( "Authorization", "Bearer a_token" )
-        stub(store, "get").yields([null, [{name: "bla", modified: 1234544444}, {name: "bar/", modified: 12345888888}]])
+        stub(store, "get").yields([null, { children: [{name: "bla", modified: 1234544444}, {name: "bar/", modified: 12345888888}], modified: 12345888888 }])
       }})
 
       it("returns the listing as JSON", function() { with(this) {
@@ -216,6 +216,7 @@ JS.Test.describe("Storage", function() { with(this) {
         check_status( 200 )
         check_header( "Access-Control-Allow-Origin", "*" )
         check_header( "Cache-Control", "no-cache, no-store" )
+        check_header( "ETag", "12345888888" )
         check_json( {"bar/": "12345888888", "bla": "1234544444"} )
       }})
     }})
@@ -223,7 +224,7 @@ JS.Test.describe("Storage", function() { with(this) {
     describe("when the store returns an empty directory listing", function() { with(this) {
       before(function() { with(this) {
         header( "Authorization", "Bearer a_token" )
-        stub(store, "get").yields([null, []])
+        stub(store, "get").yields([null, { children: [], modified: 12345888888 }])
       }})
 
       it("returns a 200 response with an empty JSON object", function() { with(this) {
@@ -231,6 +232,7 @@ JS.Test.describe("Storage", function() { with(this) {
         check_status( 200 )
         check_header( "Access-Control-Allow-Origin", "*" )
         check_header( "Cache-Control", "no-cache, no-store" )
+        check_header( "ETag", "12345888888" )
         check_json( {} )
       }})
     }})

--- a/spec/store_spec.js
+++ b/spec/store_spec.js
@@ -249,7 +249,7 @@ JS.Test.describe("Stores", function() { with(this) {
           it("creates the parent directory", function(resume) { with(this) {
             store.get("boris", "/photos/foo/bar/", null, function(error, items) {
               resume(function() {
-                assertEqual( [{name: "qux", modified: date}], items )
+                assertEqual( { children: [{name: "qux", modified: date}], modified: date }, items )
               })
             })
           }})
@@ -257,7 +257,7 @@ JS.Test.describe("Stores", function() { with(this) {
           it("creates the grandparent directory", function(resume) { with(this) {
             store.get("boris", "/photos/foo/", null, function(error, items) {
               resume(function() {
-                assertEqual( [{name: "bar/", modified: date}], items )
+                assertEqual( { children: [{name: "bar/", modified: date}], modified: date }, items )
               })
             })
           }})
@@ -385,7 +385,7 @@ JS.Test.describe("Stores", function() { with(this) {
             store.get("boris", "/photos/", null, function(error, items) {
               resume(function() {
                 assertNull( error )
-                assertEqual( [{name: "bar/", modified: date}, {name: "bla", modified: date}], items )
+                assertEqual( { children: [{name: "bar/", modified: date}, {name: "bla", modified: date}], modified: date }, items )
               })
             })
           }})
@@ -394,7 +394,7 @@ JS.Test.describe("Stores", function() { with(this) {
             store.get("zebcoe", "/", null, function(error, items) {
               resume(function() {
                 assertNull( error )
-                assertEqual( [{name: "tv/", modified: date}], items )
+                assertEqual( { children: [{name: "tv/", modified: date}], modified: date }, items )
               })
             })
           }})
@@ -419,7 +419,7 @@ JS.Test.describe("Stores", function() { with(this) {
               store.get("boris", "/photos/", null, function(error, items) {
                 resume(function() {
                   assertNull( error )
-                  assertEqual( [{name: "bar/", modified: date}, {name: "bla", modified: date}], items )
+                  assertEqual( { children: [{name: "bar/", modified: date}, {name: "bla", modified: date}], modified: date }, items )
                 })
               })
             }})


### PR DESCRIPTION
draft-dejong-remotestorage-01 is not very explicit about returning ETags for folders, but it has a couple of paragraphs that can be interpreted that way, such as "All successful requests MUST return an 'ETag' header [HTTP] with, in the case of GET, the current version." Since you are storing and updating version information for folders anyway, why not expose them?
