### PR TITLE
use 304 instead of 412 for GETs whose precondition fail

### DIFF
--- a/lib/controllers/storage.js
+++ b/lib/controllers/storage.js
@@ -50,7 +50,7 @@ Storage.action('get', function() {
 
       if (versionMatch) {
         delete self._headers['Content-Type'];
-        self.response.writeHead(412, self._headers);
+        self.response.writeHead(304, self._headers);
         return self.response.end();
       }
 


### PR DESCRIPTION
see https://github.com/remotestorage/spec/issues/23
