### PR TITLE
Allow If-None-Match header for storage requests

### DIFF
--- a/lib/controllers/storage.js
+++ b/lib/controllers/storage.js
@@ -20,7 +20,7 @@ Storage.VALID_NAME = core.VALID_NAME;
 
 Storage.action('options', function() {
   this._headers['Access-Control-Allow-Methods'] = 'GET, PUT, DELETE';
-  this._headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Length, Content-Type, Origin, X-Requested-With';
+  this._headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Length, Content-Type, Origin, X-Requested-With, If-None-Match';
   this.response.writeHead(200, this._headers);
   this.response.end();
 });

--- a/spec/restore/storage_spec.js
+++ b/spec/restore/storage_spec.js
@@ -56,7 +56,7 @@ JS.Test.describe("Storage", function() { with(this) {
       check_status( 200 )
       check_header( "Access-Control-Allow-Origin", "*" )
       check_header( "Access-Control-Allow-Methods", "GET, PUT, DELETE" )
-      check_header( "Access-Control-Allow-Headers", "Authorization, Content-Length, Content-Type, Origin, X-Requested-With" )
+      check_header( "Access-Control-Allow-Headers", "Authorization, Content-Length, Content-Type, Origin, X-Requested-With, If-None-Match" )
       check_header( "Cache-Control", "no-cache, no-store" )
       check_body( "" )
     }})


### PR DESCRIPTION
http://tools.ietf.org/html/draft-dejong-remotestorage-01 adds support
for conditional requests using the If-None-Match header. This change
fixes remotestorage.js 0.8 not working with restore due to using that
header by default.
