### PR TITLE
Fix compatibility problems with client lib 0.8.1

### DIFF
--- a/lib/controllers/storage.js
+++ b/lib/controllers/storage.js
@@ -20,7 +20,7 @@ Storage.VALID_NAME = core.VALID_NAME;
 
 Storage.action('options', function() {
   this._headers['Access-Control-Allow-Methods'] = 'GET, PUT, DELETE';
-  this._headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Length, Content-Type, Origin, X-Requested-With';
+  this._headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Length, Content-Type, Origin, X-Requested-With, If-None-Match, If-Match';
   this.response.writeHead(200, this._headers);
   this.response.end();
 });
@@ -50,7 +50,7 @@ Storage.action('get', function() {
 
       if (versionMatch) {
         delete self._headers['Content-Type'];
-        self.response.writeHead(412, self._headers);
+        self.response.writeHead(304, self._headers);
         return self.response.end();
       }
 
@@ -148,6 +148,7 @@ Storage.prototype.getVersion = function() {
 
 Storage.prototype.setVersion = function(timestamp) {
   if (!timestamp) return;
+  this._headers['Access-Control-Expose-Headers'] = 'ETag';
   this._headers['ETag'] = timestamp.toString();
 };
 


### PR DESCRIPTION
See https://github.com/remotestorage/spec/issues/23 : respond with 304 instead of 412 when the If-None-Match condition on a GET request fails.
Also, allow the use of ETags.
