### PR TITLE
Update reStore to handle new way of handling ejs params, and peg dependency versions for reference.

### DIFF
--- a/lib/controllers/base.js
+++ b/lib/controllers/base.js
@@ -108,10 +108,9 @@ Controller.prototype.renderHTML = function(status, file, locals) {
     host:   this.getHost(),
     title:  locals.title || '',
     signup: this.server._allow.signup,
-    body:   ejs.render(body.toString(), {locals: locals})
+    body:   ejs.render(body.toString(), locals)
   };
-
-  var html = new Buffer(ejs.render(layout.toString(), {locals: globals}));
+  var html = new Buffer(ejs.render(layout.toString(), globals));
 
   response.writeHead(status, {
     'Content-Length': html.length,

--- a/lib/controllers/base.js
+++ b/lib/controllers/base.js
@@ -72,7 +72,7 @@ Controller.prototype.renderXRD = function(file, locals) {
       template = this.readFile(viewDir + file);
 
   locals = locals || {};
-  var body = new Buffer(ejs.render(template.toString(), {locals: locals}));
+  var body = new Buffer(ejs.render(template.toString(), locals));
 
   response.writeHead(200, {
     'Access-Control-Allow-Origin': this.request.headers.origin || '*',

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
 , "engines"         : {"node": ">=0.8.0"}
 , "main"            : "./lib/restore.js"
 
-, "dependencies"    : { "async": ""
-                      , "ejs": ""
-                      , "mkdirp": ""
-                      , "redis": ">= 0.8.2"
+, "dependencies"    : { "async": "^0.9.0"
+                      , "ejs": "^2.0.8"
+                      , "mkdirp": "^0.5.0"
+                      , "redis": "^0.12.1"
                       }
 , "devDependencies" : { "jstest": ""
                       , "rimraf": ""


### PR DESCRIPTION
resolves #28 