### PR TITLE
fix a null[0] when ifMatch/ifNone exists but not numeric e.g. *

### DIFF
--- a/lib/controllers/storage.js
+++ b/lib/controllers/storage.js
@@ -141,8 +141,12 @@ Storage.prototype.getVersion = function() {
       ifMatch = headers['if-match'],
       ifNone  = headers['if-none-match'];
 
-  if (ifMatch) return parseInt(ifMatch.match(/\d+/)[0], 10);
-  if (ifNone)  return parseInt(ifNone.match(/\d+/)[0], 10);
+  if (ifMatch && ifMatch.match(/\d+/)) {
+    return parseInt(ifMatch.match(/\d+/)[0], 10);
+  }
+  if (ifNone && ifNone.match(/\d+/)) {
+    return parseInt(ifNone.match(/\d+/)[0], 10);
+  }
 
   return null;
 };


### PR DESCRIPTION
browser was sending `If-None-Match: *`, causing `"*".match(/\d+/)[0]` → `null[0]`.