### PR TITLE
baseURL option support.

### DIFF
--- a/lib/controllers/base.js
+++ b/lib/controllers/base.js
@@ -104,12 +104,12 @@ Controller.prototype.renderHTML = function(status, file, locals) {
       body     = this.readFile(viewDir + file);
 
   locals = locals || {};
-  locals.baseURL = this.server._baseURL;
+  locals.basePath = this.server._basePath;
 
   var globals = {
     scheme: this.request.secure ? 'https' : 'http',
     host:   this.getHost(),
-    baseURL: this.server._baseURL,
+    basePath: this.server._basePath,
     title:  locals.title || '',
     signup: this.server._allow.signup,
     body:   ejs.render(body.toString(), locals)

--- a/lib/controllers/base.js
+++ b/lib/controllers/base.js
@@ -104,10 +104,12 @@ Controller.prototype.renderHTML = function(status, file, locals) {
       body     = this.readFile(viewDir + file);
 
   locals = locals || {};
+  locals.baseURL = this.server._baseURL;
 
   var globals = {
     scheme: this.request.secure ? 'https' : 'http',
     host:   this.getHost(),
+    baseURL: this.server._baseURL,
     title:  locals.title || '',
     signup: this.server._allow.signup,
     body:   ejs.render(body.toString(), locals)

--- a/lib/controllers/web_finger.js
+++ b/lib/controllers/web_finger.js
@@ -77,7 +77,7 @@ WebFinger.prototype.getOrigin = function() {
   var scheme = (this.request.secure || this.server._forceSSL) ? 'https' : 'http',
       host   = this.request.headers['x-forwarded-host'] || this.request.headers.host;
 
-  return scheme + '://' + host;
+  return scheme + '://' + host + this.server._baseURL;
 };
 
 module.exports = WebFinger;

--- a/lib/controllers/web_finger.js
+++ b/lib/controllers/web_finger.js
@@ -77,7 +77,7 @@ WebFinger.prototype.getOrigin = function() {
   var scheme = (this.request.secure || this.server._forceSSL) ? 'https' : 'http',
       host   = this.request.headers['x-forwarded-host'] || this.request.headers.host;
 
-  return scheme + '://' + host + this.server._baseURL;
+  return scheme + '://' + host + this.server._basePath;
 };
 
 module.exports = WebFinger;

--- a/lib/restore.js
+++ b/lib/restore.js
@@ -23,7 +23,7 @@ var Restore = function(options) {
   this._fileCache  = {};
   this._allow      = options.allow || {};
   this._cacheViews = options.cacheViews !== false;
-  this._baseURL    = options.baseURL || ''
+  this._basePath   = options.basePath || ''
 
   var self = this;
 
@@ -93,52 +93,52 @@ Restore.prototype.dispatch = function(request, response) {
   var method = request.method.toUpperCase(),
       uri    = url.parse(request.url, true),
       match  = null,
-      startBaseURL = new RegExp('^\/?' + this._baseURL + '\/?');
+      startBasePath = new RegExp('^\/?' + this._basePath + '\/?');
 
   request.secure = this.isSecureRequest(request);
 
-  if (!uri.pathname.match(startBaseURL)) {
-    response.writeHead(302, { 'Location': this._baseURL})
+  if (!uri.pathname.match(startBasePath)) {
+    response.writeHead(302, {'Location': this._basePath})
     return response.end()
   }
 
-  // remove baseURL and eventually a final '/' before real path
-  uri.pathname = uri.pathname.replace(startBaseURL, '')
+  // remove basePath before real path
+  uri.pathname = uri.pathname.replace(startBasePath, '/')
 
   if (/(^|\/)\.\.(\/|$)/.test(uri.pathname)) {
     response.writeHead(400, {'Access-Control-Allow-Origin': request.headers.origin || '*'});
     return response.end();
   }
 
-  if (method === 'GET' && uri.pathname === '')
+  if (method === 'GET' && uri.pathname === '/')
     return new Assets(this, request, response).renderHTML(200, 'index.html', {title: 'reStore'});
 
-  match = uri.pathname.match(/^assets\/([^\/]+)$/);
+  match = uri.pathname.match(/^\/assets\/([^\/]+)$/);
   if (method === 'GET' && match)
     return new Assets(this, request, response).serve(match[1]);
 
-  match = uri.pathname.match(/^\.well-known\/(host-meta|webfinger)(\.[a-z]+)?$/);
+  match = uri.pathname.match(/^\/\.well-known\/(host-meta|webfinger)(\.[a-z]+)?$/);
   if (method === 'GET' && match)
     return new WebFinger(this, request, response).hostMeta(match[1], match[2]);
 
-  match = uri.pathname.match(/^webfinger\/(jrd|xrd)$/);
+  match = uri.pathname.match(/^\/webfinger\/(jrd|xrd)$/);
   if (method === 'GET' && match)
     return new WebFinger(this, request, response).account(match[1]);
 
-  match = uri.pathname.match(/^oauth\/(.*)$/);
+  match = uri.pathname.match(/^\/oauth\/(.*)$/);
   if (method === 'GET' && match)
     return new OAuth(this, request, response).showForm(decodeURIComponent(match[1]));
 
-  if (method === 'POST' && uri.pathname === 'oauth')
+  if (method === 'POST' && uri.pathname === '/oauth')
     return new OAuth(this, request, response).authenticate();
 
-  if (uri.pathname === 'signup') {
+  if (uri.pathname === '/signup') {
     var users = new Users(this, request, response);
     if (method === 'GET') return users.showForm();
     if (method === 'POST') return users.register();
   }
 
-  match = uri.pathname.match(/^storage\/([^\/]+)(.*)$/);
+  match = uri.pathname.match(/^\/storage\/([^\/]+)(.*)$/);
   if (match) {
     var username = decodeURIComponent(match[1]).split('@')[0],
         path     = match[2],
@@ -155,7 +155,7 @@ Restore.prototype.dispatch = function(request, response) {
     if (method === 'DELETE')  return storage.delete();
   }
 
-  new Assets(this, request, response).errorPage(404, 'Not found ' + uri.pathname);
+  new Assets(this, request, response).errorPage(404, 'Not found');
 };
 
 Restore.prototype.isSecureRequest = function(r) {

--- a/lib/restore.js
+++ b/lib/restore.js
@@ -23,6 +23,7 @@ var Restore = function(options) {
   this._fileCache  = {};
   this._allow      = options.allow || {};
   this._cacheViews = options.cacheViews !== false;
+  this._baseURL    = options.baseURL || ''
 
   var self = this;
 
@@ -91,44 +92,53 @@ Restore.prototype.handle = function(request, response) {
 Restore.prototype.dispatch = function(request, response) {
   var method = request.method.toUpperCase(),
       uri    = url.parse(request.url, true),
-      match  = null;
+      match  = null,
+      startBaseURL = new RegExp('^\/?' + this._baseURL + '\/?');
 
   request.secure = this.isSecureRequest(request);
+
+  if (!uri.pathname.match(startBaseURL)) {
+    response.writeHead(302, { 'Location': this._baseURL})
+    return response.end()
+  }
+
+  // remove baseURL and eventually a final '/' before real path
+  uri.pathname = uri.pathname.replace(startBaseURL, '')
 
   if (/(^|\/)\.\.(\/|$)/.test(uri.pathname)) {
     response.writeHead(400, {'Access-Control-Allow-Origin': request.headers.origin || '*'});
     return response.end();
   }
 
-  if (method === 'GET' && uri.pathname === '/')
+  if (method === 'GET' && uri.pathname === '')
     return new Assets(this, request, response).renderHTML(200, 'index.html', {title: 'reStore'});
 
-  match = uri.pathname.match(/^\/assets\/([^\/]+)$/);
+  match = uri.pathname.match(/^assets\/([^\/]+)$/);
   if (method === 'GET' && match)
     return new Assets(this, request, response).serve(match[1]);
 
-  match = uri.pathname.match(/^\/\.well-known\/(host-meta|webfinger)(\.[a-z]+)?$/);
+  match = uri.pathname.match(/^\.well-known\/(host-meta|webfinger)(\.[a-z]+)?$/);
   if (method === 'GET' && match)
     return new WebFinger(this, request, response).hostMeta(match[1], match[2]);
 
-  match = uri.pathname.match(/^\/webfinger\/(jrd|xrd)$/);
+  match = uri.pathname.match(/^webfinger\/(jrd|xrd)$/);
   if (method === 'GET' && match)
     return new WebFinger(this, request, response).account(match[1]);
 
-  match = uri.pathname.match(/^\/oauth\/(.*)$/);
+  match = uri.pathname.match(/^oauth\/(.*)$/);
   if (method === 'GET' && match)
     return new OAuth(this, request, response).showForm(decodeURIComponent(match[1]));
 
-  if (method === 'POST' && uri.pathname === '/oauth')
+  if (method === 'POST' && uri.pathname === 'oauth')
     return new OAuth(this, request, response).authenticate();
 
-  if (uri.pathname === '/signup') {
+  if (uri.pathname === 'signup') {
     var users = new Users(this, request, response);
     if (method === 'GET') return users.showForm();
     if (method === 'POST') return users.register();
   }
 
-  match = uri.pathname.match(/^\/storage\/([^\/]+)(.*)$/);
+  match = uri.pathname.match(/^storage\/([^\/]+)(.*)$/);
   if (match) {
     var username = decodeURIComponent(match[1]).split('@')[0],
         path     = match[2],
@@ -145,7 +155,7 @@ Restore.prototype.dispatch = function(request, response) {
     if (method === 'DELETE')  return storage.delete();
   }
 
-  new Assets(this, request, response).errorPage(404, 'Not found');
+  new Assets(this, request, response).errorPage(404, 'Not found ' + uri.pathname);
 };
 
 Restore.prototype.isSecureRequest = function(r) {

--- a/lib/views/auth.html
+++ b/lib/views/auth.html
@@ -16,7 +16,7 @@
     <p class="error"><%= error %></p>
   <% } %>
 
-  <form method="POST" action="<%= baseURL %>/oauth">
+  <form method="POST" action="<%= basePath %>/oauth">
     <input type="hidden" name="client_id" value="<%= client_id %>">
     <input type="hidden" name="redirect_uri" value="<%= redirect_uri %>">
     <input type="hidden" name="response_type" value="<%= response_type %>">

--- a/lib/views/auth.html
+++ b/lib/views/auth.html
@@ -16,7 +16,7 @@
     <p class="error"><%= error %></p>
   <% } %>
 
-  <form method="POST" action="/oauth">
+  <form method="POST" action="<%= baseURL %>/oauth">
     <input type="hidden" name="client_id" value="<%= client_id %>">
     <input type="hidden" name="redirect_uri" value="<%= redirect_uri %>">
     <input type="hidden" name="response_type" value="<%= response_type %>">

--- a/lib/views/index.html
+++ b/lib/views/index.html
@@ -1,4 +1,4 @@
-<p><img src="<%= baseURL %>/assets/remotestorage.svg"></p>
+<p><img src="<%= basePath %>/assets/remotestorage.svg"></p>
 
 <p>This is <em>reStore</em>, an open-source <a
   href="http://remotestorage.io/">remoteStorage</a> server. If you would like

--- a/lib/views/index.html
+++ b/lib/views/index.html
@@ -1,4 +1,4 @@
-<p><img src="/assets/remotestorage.svg"></p>
+<p><img src="<%= baseURL %>/assets/remotestorage.svg"></p>
 
 <p>This is <em>reStore</em>, an open-source <a
   href="http://remotestorage.io/">remoteStorage</a> server. If you would like

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link href="<%= scheme %>://fonts.googleapis.com/css?family=Ubuntu+Mono|Open+Sans:400italic,400,700" rel="stylesheet" type="text/css">
     <title><%= title %></title>
-    <link rel="stylesheet" type="text/css" href="<%= baseURL %>/assets/style.css">
+    <link rel="stylesheet" type="text/css" href="<%= basePath %>/assets/style.css">
   </head>
   <body>
 
@@ -14,8 +14,8 @@
         <h1><span>Remote Storage</span> <a href="/"><%= host %></a></h1>
 
         <ul class="nav">
-          <li><a href="<%= baseURL %>/">Home</a></li>
-          <% if (signup) { %><li><a href="<%= baseURL %>/signup">Sign up</a></li><% } %>
+          <li><a href="<%= basePath %>/">Home</a></li>
+          <% if (signup) { %><li><a href="<%= basePath %>/signup">Sign up</a></li><% } %>
         </ul>
       </div>
     </div>

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link href="<%= scheme %>://fonts.googleapis.com/css?family=Ubuntu+Mono|Open+Sans:400italic,400,700" rel="stylesheet" type="text/css">
     <title><%= title %></title>
-    <link rel="stylesheet" type="text/css" href="/assets/style.css">
+    <link rel="stylesheet" type="text/css" href="<%= baseURL %>/assets/style.css">
   </head>
   <body>
 
@@ -14,8 +14,8 @@
         <h1><span>Remote Storage</span> <a href="/"><%= host %></a></h1>
 
         <ul class="nav">
-          <li><a href="/">Home</a></li>
-          <% if (signup) { %><li><a href="/signup">Sign up</a></li><% } %>
+          <li><a href="<%= baseURL %>/">Home</a></li>
+          <% if (signup) { %><li><a href="<%= baseURL %>/signup">Sign up</a></li><% } %>
         </ul>
       </div>
     </div>

--- a/lib/views/signup.html
+++ b/lib/views/signup.html
@@ -1,6 +1,6 @@
 <h2>Sign up</h2>
 
-<form method="post" action="<%= baseURL %>/signup">
+<form method="post" action="<%= basePath %>/signup">
   <% if (error) { %>
     <p class="error"><%= error.message %></p>
   <% } %>

--- a/lib/views/signup.html
+++ b/lib/views/signup.html
@@ -1,6 +1,6 @@
 <h2>Sign up</h2>
 
-<form method="post" action="/signup">
+<form method="post" action="<%= baseURL %>/signup">
   <% if (error) { %>
     <p class="error"><%= error.message %></p>
   <% } %>


### PR DESCRIPTION
Needed if you want to host reStore without a domain for itself alone.
Let's say you own your 'www.example.com' and want to host reStore
at 'www.example.com/reStore' now you can.

This PR introduces a new `baseURL` option you can use for this.
