### PR TITLE
Simple reStore configurable bin script

### DIFF
--- a/bin/conf.example.json
+++ b/bin/conf.example.json
@@ -1,0 +1,16 @@
+{
+  "allow_signup": true,
+  "storage_path": "/home/les/remoteStorage",
+  "cache_views": true,
+  "http": {
+    "host": "0.0.0.0",
+    "port": 8000
+  },
+  "https": {
+    "enable": true,
+    "force": true,
+    "port": 4443,
+    "cert": "/etc/letsencrypt/live/mystuff.ns0.it/cert.pem",
+    "key": "/etc/letsencrypt/live/mystuff.ns0.it/privkey.pem"
+  }
+}

--- a/bin/conf.example.json
+++ b/bin/conf.example.json
@@ -1,6 +1,6 @@
 {
   "allow_signup": true,
-  "storage_path": "/home/les/remoteStorage",
+  "storage_path": "/usr/share/reStore",
   "cache_views": true,
   "http": {
     "host": "0.0.0.0",

--- a/bin/conf.example.json
+++ b/bin/conf.example.json
@@ -7,10 +7,11 @@
     "port": 8000
   },
   "https": {
-    "enable": true,
-    "force": true,
+    "enable": false,
+    "force": false,
     "port": 4443,
-    "cert": "/etc/letsencrypt/live/mystuff.ns0.it/cert.pem",
-    "key": "/etc/letsencrypt/live/mystuff.ns0.it/privkey.pem"
-  }
+    "cert": "/etc/letsencrypt/live/example.com/cert.pem",
+    "key": "/etc/letsencrypt/live/example.com/privkey.pem"
+  },
+  "baseURL": ""
 }

--- a/bin/server.js
+++ b/bin/server.js
@@ -32,26 +32,9 @@ var remoteStorageServer = {
       description: 'NodeJS remoteStorage server'
     })
 
-    parser.addArgument (['-C','--cert'], 
-      { help: `ssl certificate (${__dirname}/ssl/server.crt)`, 
-      default: __dirname + '/ssl/server.crt'})
-    
-    parser.addArgument (['-K','--key'], 
-      { help: `ssl certificate (${__dirname}/ssl/server.key)`, 
-      default: __dirname + '/ssl/server.key'})
-
-    parser.addArgument(['-p','--path'], {
-      help: 'path used to store user\'s data',
-      default: 'remoteStorageData'
-    })
-
     parser.addArgument(['-c','--conf'], {
-      help: 'configuration file (use -j to create an example)'
-    })
-
-    parser.addArgument(['-j','--conf-example'], {
-      help: 'print out a configuration example',
-      action: 'storeTrue'
+      help: 'Path to configuration',
+      required: true
     })
 
     return parser.parseArgs()

--- a/bin/server.js
+++ b/bin/server.js
@@ -14,23 +14,38 @@ var remoteStorageServer = {
   // parse cli args
   parseArgs: function() {
     var ArgumentParser = require('argparse').ArgumentParser
+    var version = require(__dirname + '/../package.json').version
     var parser = new ArgumentParser({
-      version: '1.0.0',
+      version: version,
       addHelp: true,
-      description: 'NodeJS remoteStorage server'
+      description: 'NodeJS remoteStorage server / ' + version
     })
 
     parser.addArgument(['-c','--conf'], {
       help: 'Path to configuration',
-      required: true
+    })
+
+    parser.addArgument(['-e','--exampleConf'], {
+      help: 'Print configuration example',
+      action: 'storeTrue'
     })
 
     return parser.parseArgs()
   },
 
   init: function() {
-    const args = this.parseArgs()
-    let conf = {}
+    var args = this.parseArgs()
+    var conf = {}
+
+    if (args.exampleConf) {
+      console.log(fs.readFileSync(__dirname + '/conf.example.json', 'utf8'))
+      return -1
+    }
+
+    if (!args.conf) {
+      console.error('[ERR] Configuration file needed (help with -h)')
+      return -1
+    }
 
     try {
       conf = this.readConf(args.conf)

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+const conf_example = 
+`{
+  // allow new user to register !
+  allow_signup: false
+  storage_path: '/home/les/remoteStorage',
+  cache_views: true,
+  http: {
+    port: 8000
+  },
+  
+  https: {
+    enable: true,
+    force: true,
+    port: 4443,
+    cert: '/etc/ssl/server.crt',
+    key: '/etc/ssl/server.key'
+  }
+}`
+
+const reStore = require('../lib/restore')
+const path = require('path')
+
+var remoteStorageServer = {
+
+  parseArgs () {
+    const ArgumentParser = require('argparse').ArgumentParser
+    const parser = new ArgumentParser({
+      version: '1.0.0',
+      addHelp: true,
+      description: 'NodeJS remoteStorage server'
+    })
+
+    parser.addArgument (['-C','--cert'], 
+      { help: `ssl certificate (${__dirname}/ssl/server.crt)`, 
+      default: __dirname + '/ssl/server.crt'})
+    
+    parser.addArgument (['-K','--key'], 
+      { help: `ssl certificate (${__dirname}/ssl/server.key)`, 
+      default: __dirname + '/ssl/server.key'})
+
+    parser.addArgument(['-p','--path'], {
+      help: 'path used to store user\'s data',
+      default: 'remoteStorageData'
+    })
+
+    parser.addArgument(['-c','--conf'], {
+      help: 'configuration file (use -j to create an example)'
+    })
+
+    parser.addArgument(['-j','--conf-example'], {
+      help: 'print out a configuration example',
+      action: 'storeTrue'
+    })
+
+    return parser.parseArgs()
+  },
+
+  checkConf (conf) {
+
+  },
+
+  init () {
+    const args = this.parseArgs()
+    let conf = {}
+
+    if (args.conf_example) {
+      console.log(conf_example)
+      return
+    }
+
+    if (args.conf) {
+      try {
+        conf = require(path.join(__dirname, args.conf))
+      } catch(e) {
+        console.error(`[ERROR] Reading '${args.conf}'`)
+        return     
+      }
+    }
+    
+    console.log(`[INFO] Starting remoteStorage engine:
+    http://${conf.http.host}:${conf.http.port}!`)
+
+    process.umask(077)
+    const store = new reStore.FileTree({path: conf.storage_path});
+    const server = new reStore({
+      store,
+      http: {
+        host: conf.http.host,
+        port: conf.http.port
+      },
+      https: {
+        host: conf.https.host,
+        port: conf.https.port,
+        force: conf.https.force,
+        cert: conf.https.cert,
+        key: conf.https.key
+      },
+      allow: {
+        signup: conf.allow_signup
+      },
+      cacheViews: conf.cache_views
+    })
+
+
+    server.boot();
+  }
+}
+
+if (require.main === module) {
+  remoteStorageServer.init()
+}
+
+

--- a/bin/server.js
+++ b/bin/server.js
@@ -44,6 +44,7 @@ var remoteStorageServer = {
     process.umask(077)
     var store = new reStore.FileTree({path: conf.storage_path});
     var server = new reStore({
+      baseURL: conf.baseURL,
       store,
       http: {
         host: conf.http.host,
@@ -51,7 +52,7 @@ var remoteStorageServer = {
       },
       https: {
         host: conf.https.host,
-        port: conf.https.port,
+        port: conf.https.enable && conf.https.port,
         force: conf.https.force,
         cert: conf.https.cert,
         key: conf.https.key

--- a/package.json
+++ b/package.json
@@ -1,29 +1,40 @@
-{ "name"            : "restore"
-, "description"     : "Simple remoteStorage server"
-, "homepage"        : "http://github.com/jcoglan/restore"
-, "author"          : "James Coglan <jcoglan@gmail.com> (http://jcoglan.com/)"
-, "keywords"        : ["remoteStorage", "webfinger", "oauth", "webdav"]
-, "license"         : "MIT"
-
-, "version"         : "0.3.0"
-, "engines"         : {"node": ">=0.8.0"}
-, "main"            : "./lib/restore.js"
-
-, "dependencies"    : { "async": ""
-                      , "ejs": ">= 2.0.0"
-                      , "lockfile": ">= 1.0.0"
-                      , "mkdirp": ""
-                      , "redis": ">= 0.8.2"
-                      }
-, "devDependencies" : { "jstest": ""
-                      , "rimraf": ""
-                      }
-
-, "scripts"         : {"test": "node spec/runner.js"}
-
-, "repository"      : { "type"  : "git"
-                      , "url"   : "git://github.com/jcoglan/restore.git"
-                      }
-
-, "bugs"            : {"url": "http://github.com/jcoglan/restore/issues"}
+{
+  "name": "restore",
+  "description": "Simple remoteStorage server",
+  "homepage": "http://github.com/jcoglan/restore",
+  "author": "James Coglan <jcoglan@gmail.com> (http://jcoglan.com/)",
+  "keywords": [
+    "remoteStorage",
+    "webfinger",
+    "oauth",
+    "webdav"
+  ],
+  "license": "MIT",
+  "version": "0.3.0",
+  "engines": {
+    "node": ">=0.8.0"
+  },
+  "main": "./lib/restore.js",
+  "dependencies": {
+    "argparse": "^1.0.7",
+    "async": "",
+    "ejs": ">= 2.0.0",
+    "lockfile": ">= 1.0.0",
+    "mkdirp": "",
+    "redis": ">= 0.8.2"
+  },
+  "devDependencies": {
+    "jstest": "",
+    "rimraf": ""
+  },
+  "scripts": {
+    "test": "node spec/runner.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jcoglan/restore.git"
+  },
+  "bugs": {
+    "url": "http://github.com/jcoglan/restore/issues"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "engines": {
     "node": ">=0.8.0"
   },
+  "bin": {
+    "reStore": "./bin/server.js"
+  },
   "main": "./lib/restore.js",
   "dependencies": {
     "argparse": "^1.0.7",


### PR DESCRIPTION
Hope this helps someone !

```
$ npm install -g restore

$ reStore -h
usage: reStore [-h] [-v] [-c CONF] [-e]

NodeJS remoteStorage server / 0.3.0

Optional arguments:
  -h, --help            Show this help message and exit.
  -v, --version         Show program's version number and exit.
  -c CONF, --conf CONF  Path to configuration
  -e, --exampleConf     Print configuration example


$ reStore -e
{
  "allow_signup": true,
  "storage_path": "/usr/share/reStore",
  "cache_views": true,
  "http": {
    "host": "127.0.0.1",
    "port": 8000
  },
  "https": {
    "enable": false,
    "force": false,
    "port": 4443,
    "cert": "/etc/letsencrypt/live/example.com/cert.pem",
    "key": "/etc/letsencrypt/live/example.com/privkey.pem"
  },
  "baseURL": ""
}

$ reStore -e > reStore.conf.json
$ # edit as you need 
$ reStore -c reStore.conf.json
[INFO] Starting remoteStorage: http://127.0.0.1:8000
```
